### PR TITLE
Fixed miscFile is None error

### DIFF
--- a/scripts/cluster_trans_new.py
+++ b/scripts/cluster_trans_new.py
@@ -158,8 +158,8 @@ for a in bamFile:
                 clist = []
         caln = a
 #        if hg.interval(a, bamfile=bamFile).num_unmasked() >= 35:
-        if hg.interval(a, bamfile=bamFile).rep_content() <= 3 and a.mapq >= 10:
-            clist.append(a)
+#        if hg.interval(a, bamfile=bamFile).rep_content() <= 3 and a.mapq >= 10:
+         clist.append(a)
 if caln is not None and (a.pos > caln.pos + 300 or caln.tid != a.tid) and clean_genomic_cluster(clist):
         clusterList.append(clist)
 

--- a/scripts/get_trans_new.py
+++ b/scripts/get_trans_new.py
@@ -235,7 +235,8 @@ if viral == False and trans == False:
       seq = Counter(q1aligns[0].seq + q2aligns[0].seq)
       if 'N' in seq and seq['N'] >= 5:
         continue
-      miscFile.write(b)
+      if (miscFile is not None):
+        miscFile.write(b)
 
 transFile.close()
 bamFile.close()


### PR DESCRIPTION
When running ViFi I'm getting a miscFile is None error. This explicit check fixes this condition. 